### PR TITLE
Partial threshold cutoffs

### DIFF
--- a/src/p7HmmReader.c
+++ b/src/p7HmmReader.c
@@ -455,7 +455,7 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
             //set the default values for the gathering thresholds to NAN, these will be overwritten if the GA line contained values
             currentPhmm->header.gatheringThresholds[0] = NAN;
             currentPhmm->header.gatheringThresholds[1] = NAN;
-            int scanVariablesFilled = sscanf(flagText, " %f %f", 
+            sscanf(flagText, " %f %f", 
               &currentPhmm->header.gatheringThresholds[0], &currentPhmm->header.gatheringThresholds[1]);
           }
           if(strcmp(firstTokenLocation, P7_HEADER_TRUSTED_FLAG) == 0){
@@ -469,7 +469,7 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
             //set the default values for the trusted cutoffs to NAN, these will be overwritten if the TC line contained values
             currentPhmm->header.trustedCutoffs[0] = NAN;
             currentPhmm->header.trustedCutoffs[1] = NAN;
-            int scanVariablesFilled = sscanf(flagText, " %f %f", 
+            sscanf(flagText, " %f %f", 
               &currentPhmm->header.trustedCutoffs[0], &currentPhmm->header.trustedCutoffs[1]);
           }
           if(strcmp(firstTokenLocation, P7_HEADER_NOISE_FLAG) == 0){
@@ -483,7 +483,7 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
             //set the default values for the noise cutoffs to NAN, these will be overwritten if the NC line contained values
             currentPhmm->header.noiseCutoffs[0] = NAN;
             currentPhmm->header.noiseCutoffs[1] = NAN;
-            int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.noiseCutoffs[0], &currentPhmm->header.noiseCutoffs[1]);
+            sscanf(flagText, " %f %f", &currentPhmm->header.noiseCutoffs[0], &currentPhmm->header.noiseCutoffs[1]);
           }
           if(strcmp(firstTokenLocation, P7_HEADER_STATS_FLAG) == 0){
             char *flagText = strtok(NULL, "");//leaving the delimeter empty goes until the string's null terminator

--- a/src/p7HmmReader.c
+++ b/src/p7HmmReader.c
@@ -452,16 +452,11 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
               printFormatError(fileSrc, lineNumber, "couldn't parse GA tag.");
               return p7HmmFormatError;
             }
-            int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.gatheringThresholds[0], &currentPhmm->header.gatheringThresholds[1]);
-            if(scanVariablesFilled == 1){
-              currentPhmm->header.gatheringThresholds[1] = NAN;
-            }
-            else if(scanVariablesFilled == 0){
-              p7HmmListDealloc(phmmList);
-              free(lineBuffer);
-              printFormatError(fileSrc, lineNumber, "expected 1 or 2 float values after GA tag.");
-              return p7HmmFormatError;
-            }
+            //set the default values for the gathering thresholds to NAN, these will be overwritten if the GA line contained values
+            currentPhmm->header.gatheringThresholds[0] = NAN;
+            currentPhmm->header.gatheringThresholds[1] = NAN;
+            int scanVariablesFilled = sscanf(flagText, " %f %f", 
+              &currentPhmm->header.gatheringThresholds[0], &currentPhmm->header.gatheringThresholds[1]);
           }
           if(strcmp(firstTokenLocation, P7_HEADER_TRUSTED_FLAG) == 0){
             char *flagText = strtok(NULL, "");//leaving the delimeter empty goes until the string's null terminator
@@ -471,16 +466,11 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
               printFormatError(fileSrc, lineNumber, "couldn't parse TC tag.");
               return p7HmmFormatError;
             }
-            int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.trustedCutoffs[0], &currentPhmm->header.trustedCutoffs[1]);
-            if(scanVariablesFilled == 1){
-              currentPhmm->header.trustedCutoffs[1] = NAN;
-            }
-            if(scanVariablesFilled == 0){
-              p7HmmListDealloc(phmmList);
-              free(lineBuffer);
-              printFormatError(fileSrc, lineNumber, "expected 1 or 2 float values after TC tag.");
-              return p7HmmFormatError;
-            }
+            //set the default values for the trusted cutoffs to NAN, these will be overwritten if the TC line contained values
+            currentPhmm->header.trustedCutoffs[0] = NAN;
+            currentPhmm->header.trustedCutoffs[1] = NAN;
+            int scanVariablesFilled = sscanf(flagText, " %f %f", 
+              &currentPhmm->header.trustedCutoffs[0], &currentPhmm->header.trustedCutoffs[1]);
           }
           if(strcmp(firstTokenLocation, P7_HEADER_NOISE_FLAG) == 0){
             char *flagText = strtok(NULL, "");//leaving the delimeter empty goes until the string's null terminator
@@ -490,16 +480,10 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
               printFormatError(fileSrc, lineNumber, "couldn't parse NC flag.");
               return p7HmmFormatError;
             }
+            //set the default values for the noise cutoffs to NAN, these will be overwritten if the NC line contained values
+            currentPhmm->header.noiseCutoffs[0] = NAN;
+            currentPhmm->header.noiseCutoffs[1] = NAN;
             int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.noiseCutoffs[0], &currentPhmm->header.noiseCutoffs[1]);
-            if(scanVariablesFilled == 1){
-              currentPhmm->header.noiseCutoffs[1] = NAN;
-            }
-            else if(scanVariablesFilled == 2){
-              p7HmmListDealloc(phmmList);
-              free(lineBuffer);
-              printFormatError(fileSrc, lineNumber, "expected 1 or 2 float values after NC flag.");
-              return p7HmmFormatError;
-            }
           }
           if(strcmp(firstTokenLocation, P7_HEADER_STATS_FLAG) == 0){
             char *flagText = strtok(NULL, "");//leaving the delimeter empty goes until the string's null terminator

--- a/src/p7HmmReader.c
+++ b/src/p7HmmReader.c
@@ -453,10 +453,13 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
               return p7HmmFormatError;
             }
             int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.gatheringThresholds[0], &currentPhmm->header.gatheringThresholds[1]);
-            if(scanVariablesFilled < 2){
+            if(scanVariablesFilled == 1){
+              currentPhmm->header.gatheringThresholds[1] = NAN;
+            }
+            else if(scanVariablesFilled == 0){
               p7HmmListDealloc(phmmList);
               free(lineBuffer);
-              printFormatError(fileSrc, lineNumber, "expected 2 float values after GA tag.");
+              printFormatError(fileSrc, lineNumber, "expected 1 or 2 float values after GA tag.");
               return p7HmmFormatError;
             }
           }
@@ -469,10 +472,13 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
               return p7HmmFormatError;
             }
             int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.trustedCutoffs[0], &currentPhmm->header.trustedCutoffs[1]);
-            if(scanVariablesFilled != 2){
+            if(scanVariablesFilled == 1){
+              currentPhmm->header.trustedCutoffs[1] = NAN;
+            }
+            if(scanVariablesFilled == 0){
               p7HmmListDealloc(phmmList);
               free(lineBuffer);
-              printFormatError(fileSrc, lineNumber, "expected 2 float values after TC tag.");
+              printFormatError(fileSrc, lineNumber, "expected 1 or 2 float values after TC tag.");
               return p7HmmFormatError;
             }
           }
@@ -485,10 +491,13 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
               return p7HmmFormatError;
             }
             int scanVariablesFilled = sscanf(flagText, " %f %f", &currentPhmm->header.noiseCutoffs[0], &currentPhmm->header.noiseCutoffs[1]);
-            if(scanVariablesFilled != 2){
+            if(scanVariablesFilled == 1){
+              currentPhmm->header.noiseCutoffs[1] = NAN;
+            }
+            else if(scanVariablesFilled == 2){
               p7HmmListDealloc(phmmList);
               free(lineBuffer);
-              printFormatError(fileSrc, lineNumber, "expected 2 float values after NC flag.");
+              printFormatError(fileSrc, lineNumber, "expected 1 or 2 float values after NC flag.");
               return p7HmmFormatError;
             }
           }


### PR DESCRIPTION
This change supports partial values for GA, TC, and NC. While the HMMER spec says that these lines should have 2 values, RFAM only has a single value for these optional lines. Now, P7HmmReader will read these models correctly, instead of erroring out. 