### PR TITLE
add error checking for file not found in readP7Hmm

### DIFF
--- a/src/p7HmmReader.c
+++ b/src/p7HmmReader.c
@@ -57,6 +57,10 @@ enum P7HmmReturnCode readP7Hmm(const char *const fileSrc, struct P7HmmList *phmm
 
     FILE *openedFile = fopen(fileSrc, "r");
 
+    if(openedFile == NULL){
+      return p7HmmFileNotFound;
+    }
+
     enum HmmReaderParserState parserState = parsingHmmIdle;
     uint32_t alphabetCardinality = 0;
     //for counting which node number we're in when we get to the model body

--- a/src/p7HmmReader.h
+++ b/src/p7HmmReader.h
@@ -14,7 +14,7 @@
 
 
 enum P7HmmReturnCode{
-  p7HmmSuccess = 0, p7HmmAllocationFailure = -1, p7HmmFormatError = -2
+  p7HmmSuccess = 0, p7HmmAllocationFailure = -1, p7HmmFormatError = -2, p7HmmFileNotFound = -3
 };
 
 enum P7Alphabet{


### PR DESCRIPTION
this fixes an error where the program would segfault on attempting to read a file that doesn't exist. now, the program handles this gracefully with a return code.